### PR TITLE
Make the parsing more defensive to things like optional parameters

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -5,7 +5,8 @@ var path = require('path')
   , debug = require('debug')('jaws-swagger:init');
 
 function _getQueryParams(method) {
-  return method.parameters
+  var parameters = method.parameters || [];
+  return parameters
     .filter(function(param) {
       return param.in === 'query';
     }).map (function(param) {
@@ -23,6 +24,10 @@ function _processPaths(paths, basePath) {
 function _processPath(pathString, path, basePath) {
   debug('pathString: %s', pathString);
   for (var method in path) {
+    if (['$ref', 'parameters'].indexOf(method) > -1) {
+      debug("Skipping " + method + " as it is not yet handled.");
+      continue;
+    }
     _processMethod(method, path[method], pathString, basePath);
   }
 }
@@ -71,8 +76,8 @@ module.exports.run = function(file, options) {
     var appDir = path.dirname(require.main.filename);
     var swagger = require(appDir + '/../' + file);
     debug('Loading swagger json file from %s', swagger);
-    _processPaths(swagger.paths, swagger.basePath);
+    _processPaths(swagger.paths, swagger.basePath || '');
   } catch (ex) {
-    console.error('Unable to load swagger file from ' + file);
+    console.error('Unable to load swagger file from ' + file, ex, ex.stack);
   }
 }


### PR DESCRIPTION
In doing some more testing, I found places where I was being too naive about the input. This is designed to work when optional properties aren't present. 